### PR TITLE
Fixing AttributeError in slice_indicator initialization

### DIFF
--- a/sliced/base.py
+++ b/sliced/base.py
@@ -116,7 +116,7 @@ def slice_y(y, n_slices=10):
             slice_partition.append(n_samples_seen)
 
     # turn partitions into an indicator
-    slice_indicator = np.ones(y.shape[0], dtype=np.int)
+    slice_indicator = np.ones(y.shape[0], dtype=np.int64)
     for j, (start_idx, end_idx) in enumerate(
             zip(slice_partition, slice_partition[1:])):
 


### PR DESCRIPTION

The issue was related to an `AttributeError` raised in the code when initializing the `slice_indicator` variable. The error occurred due to the usage of `np.int` as the dtype argument in the `np.ones()` function. In earlier versions of NumPy, `np.int` was a deprecated alias for the built-in `int` type. However, starting from NumPy 1.20, these aliases were removed.

To resolve the issue, the code was modified by changing the dtype argument from `np.int` to `np.int64` to specify the desired precision explicitly. The modified code snippet looks as follows:

```python
# turn partitions into an indicator
slice_indicator = np.ones(y.shape[0], dtype=np.int64)
```

This change ensures compatibility with the latest versions of NumPy and resolves the `AttributeError` related to the use of `np.int` in the code. The modified code should now execute without any errors.

By making this fix, the issue has been resolved, and the code functions as intended, initializing the `slice_indicator` variable with the correct dtype.